### PR TITLE
Fix Resque.enqueue_at_with_queue method

### DIFF
--- a/lib/resque_spec/scheduler.rb
+++ b/lib/resque_spec/scheduler.rb
@@ -6,6 +6,7 @@ module ResqueSpec
       if klass.respond_to? :enqueue_at
         klass.instance_eval do
           alias :enqueue_at_without_resque_spec :enqueue_at
+          alias :enqueue_at_with_queue_without_resque_spec :enqueue_at_with_queue
           alias :enqueue_in_without_resque_spec :enqueue_in
           alias :remove_delayed_without_resque_spec :remove_delayed
         end
@@ -22,7 +23,7 @@ module ResqueSpec
     end
 
     def enqueue_at_with_queue(queue, time, klass, *args)
-      return enqueue_at_with_queue_without_resque_spec(time, klass, *args) if ResqueSpec.disable_ext && respond_to?(:enqueue_at_with_queue_without_resque_spec)
+      return enqueue_at_with_queue_without_resque_spec(queue, time, klass, *args) if ResqueSpec.disable_ext && respond_to?(:enqueue_at_with_queue_without_resque_spec)
 
       ResqueSpec.enqueue_at_with_queue(queue, time, klass, *args)
     end

--- a/spec/resque_spec/scheduler_spec.rb
+++ b/spec/resque_spec/scheduler_spec.rb
@@ -210,6 +210,14 @@ describe ResqueSpec do
         end
       end
 
+      describe ".enqueue_at_with_queue" do
+        it "calls the original Resque.enqueue_at_with_queue method" do
+          timestamp = Time.now
+          Resque.should_receive(:enqueue_at_with_queue_without_resque_spec).with("test", NameFromClassMethod, 1)
+          Resque.enqueue_at_with_queue("test", NameFromClassMethod, 1)
+        end
+      end
+
       describe ".enqueue_in" do
         it "calls the original Resque.enqueue_in method" do
           wait_time = 500


### PR DESCRIPTION
I want to skip usage of ResqueSpec for some special test case using with `without_resque_spec` block option. 
`Job.set(...).perform_later` causes ResqueSpec.enqueue_at_with_queue_without_resque_spec method 
I've found 2 places, that as for me should be fixed
- [x] `enqueue_at_with_queue_without_resque_spec` doesn't have `queue` argument
- [x] `enqueue_at_with_queue_without_resque_spec` is absent in the list of aliases of class included block